### PR TITLE
©SBI - Activation Firewall et PING

### DIFF
--- a/©SBI - Activation Firewall et PING
+++ b/©SBI - Activation Firewall et PING
@@ -1,0 +1,3 @@
+netsh advfirewall set allprofiles state on
+netsh advfirewall firewall add rule name= "PING" dir=in action=allow protocol=ICMPv4
+Enable-NetFirewallRule -DisplayGroup "Bureau à Distance"


### PR DESCRIPTION
Ce script permet : 

- Active le firewall
- Crée une règle autorisant le ping
- Crée une règle autorisant les accès sur le port 3389
